### PR TITLE
disallow typescript 7 for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,8 @@ updates:
         versions: [ ">=10.0.0" ]
       - dependency-name: "ava"
         versions: [ ">=7.0.0" ]
+      - dependency-name: "typescript"
+        versions: [ ">=7.0.0" ]
 
     # Disable rebasing for all pull requests
     rebase-strategy: "disabled"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependabot ignoriert nun TypeScript-Versionen ab 7.0.0 bei npm-Abhängigkeiten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->